### PR TITLE
News Viewer title in expander fix without crash

### DIFF
--- a/source/Views/DetailsViewGameOverview.xaml
+++ b/source/Views/DetailsViewGameOverview.xaml
@@ -1368,14 +1368,30 @@
 																	VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource GlyphBrush}"/>
 																<TextBlock VerticalAlignment="Center" Text=" Hltb  " Typography.Capitals="SmallCaps"
 																	Style="{DynamicResource BaseTextBlockStyle}" FontSize="{DynamicResource FontSizeLarge}"/>
-															</StackPanel><!-- 
-															<StackPanel Orientation="Horizontal" Tag="{PluginSettings Plugin=NewsViewer, Path=ReviewsAvailable, FallbackValue=False}"
+															</StackPanel> 
+															<StackPanel Orientation="Horizontal" Tag="{PluginStatus Plugin=NewsViewer_15e03ffe-90f6-4e8e-bd4d-94514777481d, Status=Installed}"
 																Visibility="{Binding RelativeSource={RelativeSource Self}, Path=Tag, Converter={StaticResource BooleanToVisibilityConverter}}" >
-																<Label Content="  " FontFamily="{StaticResource FontIcoFont}" FontSize="{DynamicResource FontSizeLarge}" 
+																<Grid>
+																<Grid.ColumnDefinitions>
+																	<ColumnDefinition Width="Auto"/>
+																	<ColumnDefinition Width="*"/>
+																</Grid.ColumnDefinitions>
+																<Grid.Style>
+																	<Style>
+																		<Setter Property="Control.Visibility" Value="Visible" />
+																		<Style.Triggers>
+																			<DataTrigger Binding="{PluginSettings Plugin=NewsViewer, Path=ReviewsAvailable, FallbackValue=False}" Value="False">
+																				<Setter Property="Control.Visibility" Value="Collapsed" />
+																			</DataTrigger>		
+																		</Style.Triggers>
+																	</Style>
+																</Grid.Style>
+																<Label Grid.Column="0" Margin="-5,0,2,0" Content="  " FontFamily="{StaticResource FontIcoFont}" FontSize="{DynamicResource FontSizeLarge}" 
 																	VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource GlyphBrush}"/>
-																<TextBlock VerticalAlignment="Center" Text="{DynamicResource LOC_NewsViewer_NewsViewerControl_NewsLabel}" Typography.Capitals="SmallCaps"
+																<TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{DynamicResource LOC_NewsViewer_NewsViewerControl_NewsLabel}" Typography.Capitals="SmallCaps"
 																	Style="{DynamicResource BaseTextBlockStyle}" FontSize="{DynamicResource FontSizeLarge}"/>
-															</StackPanel> -->
+																</Grid>
+															</StackPanel>
 														</StackPanel>
 													</Expander.Header>
 													<Expander.Content>												

--- a/source/Views/GridViewGameOverview.xaml
+++ b/source/Views/GridViewGameOverview.xaml
@@ -1223,14 +1223,30 @@
 																				VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource GlyphBrush}"/>
 																			<TextBlock VerticalAlignment="Center" Text=" Hltb " Typography.Capitals="SmallCaps"
 																				Style="{DynamicResource BaseTextBlockStyle}" FontSize="{DynamicResource FontSizeLarge}"/>
-																		</StackPanel>
-																		<!-- <StackPanel Orientation="Horizontal" Tag="{PluginSettings Plugin=NewsViewer, Path=ReviewsAvailable, FallbackValue=False}"
+																		</StackPanel>																		
+																		<StackPanel Orientation="Horizontal" Tag="{PluginStatus Plugin=NewsViewer_15e03ffe-90f6-4e8e-bd4d-94514777481d, Status=Installed}"
 																			Visibility="{Binding RelativeSource={RelativeSource Self}, Path=Tag, Converter={StaticResource BooleanToVisibilityConverter}}" >
-																			<Label Content="  " FontFamily="{StaticResource FontIcoFont}" FontSize="{DynamicResource FontSizeLarge}" 
-																				VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource GlyphBrush}"/>
-																			<TextBlock VerticalAlignment="Center" Text="{DynamicResource LOC_NewsViewer_NewsViewerControl_NewsLabel}" Typography.Capitals="SmallCaps"
+																			<Grid>
+																			<Grid.ColumnDefinitions>
+																				<ColumnDefinition Width="Auto"/>
+																				<ColumnDefinition Width="*"/>
+																			</Grid.ColumnDefinitions>
+																			<Grid.Style>
+																				<Style>
+																					<Setter Property="Control.Visibility" Value="Visible" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{PluginSettings Plugin=NewsViewer, Path=ReviewsAvailable, FallbackValue=False}" Value="False">
+																							<Setter Property="Control.Visibility" Value="Collapsed" />
+																						</DataTrigger>		
+																					</Style.Triggers>
+																				</Style>
+																			</Grid.Style>
+																			<Label Grid.Column="0" Margin="-5,0,2,0" Content="  " FontFamily="{StaticResource FontIcoFont}" FontSize="{DynamicResource FontSizeLarge}" 
+																				VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource GlyphBrush}"/>
+																			<TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{DynamicResource LOC_NewsViewer_NewsViewerControl_NewsLabel}" Typography.Capitals="SmallCaps"
 																				Style="{DynamicResource BaseTextBlockStyle}" FontSize="{DynamicResource FontSizeLarge}"/>
-																		</StackPanel> -->
+																			</Grid>
+																		</StackPanel>																		
 																	</StackPanel>
 																</Expander.Header>
 																<Expander.Content>												


### PR DESCRIPTION
"PluginStatus Installed" now trigger the "PluginSettings ReviewsAvailable" that load the News Viewer title only when said plugin is installed